### PR TITLE
ATtiny85 support

### DIFF
--- a/Adafruit_MCP23008.cpp
+++ b/Adafruit_MCP23008.cpp
@@ -16,7 +16,11 @@
 #else
  #include "WProgram.h"
 #endif
+#if defined(__AVR_ATtiny85__) || (__AVR_ATtiny2313__)
+#include <TinyWireM.h>
+#else
 #include <Wire.h>
+#endif
 #include <avr/pgmspace.h>
 #include "Adafruit_MCP23008.h"
 
@@ -30,8 +34,24 @@ void Adafruit_MCP23008::begin(uint8_t addr) {
   }
   i2caddr = addr;
 
+#if defined(__AVR_ATtiny85__) || (__AVR_ATtiny2313__)
+  TinyWireM.begin();
+  TinyWireM.beginTransmission(MCP23008_ADDRESS | i2caddr);
+  TinyWireM.send(MCP23008_IODIR);
+  TinyWireM.send(0xFF);  // all inputs
+  TinyWireM.send(0x00);
+  TinyWireM.send(0x00);
+  TinyWireM.send(0x00);
+  TinyWireM.send(0x00);
+  TinyWireM.send(0x00);
+  TinyWireM.send(0x00);
+  TinyWireM.send(0x00);
+  TinyWireM.send(0x00);
+  TinyWireM.send(0x00);
+  TinyWireM.endTransmission();
+#else
   Wire.begin();
-
+  
   // set defaults!
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
 #if ARDUINO >= 100
@@ -60,7 +80,7 @@ void Adafruit_MCP23008::begin(uint8_t addr) {
   Wire.send(0x00);	
 #endif
   Wire.endTransmission();
-
+#endif
 }
 
 void Adafruit_MCP23008::begin(void) {
@@ -147,6 +167,13 @@ uint8_t Adafruit_MCP23008::digitalRead(uint8_t p) {
 }
 
 uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
+#if defined(__AVR_ATtiny85__) || (__AVR_ATtiny2313__)
+  TinyWireM.beginTransmission(MCP23008_ADDRESS | i2caddr);
+  TinyWireM.send(addr);	
+  TinyWireM.endTransmission();
+  TinyWireM.requestFrom(MCP23008_ADDRESS | i2caddr, 1);
+  return TinyWireM.receive();
+#else
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
 #if ARDUINO >= 100
   Wire.write((byte)addr);	
@@ -161,10 +188,17 @@ uint8_t Adafruit_MCP23008::read8(uint8_t addr) {
 #else
   return Wire.receive();
 #endif
+#endif
 }
 
 
 void Adafruit_MCP23008::write8(uint8_t addr, uint8_t data) {
+#if defined(__AVR_ATtiny85__) || (__AVR_ATtiny2313__)
+  TinyWireM.beginTransmission(MCP23008_ADDRESS | i2caddr);
+  TinyWireM.send(addr);	
+  TinyWireM.send(data);
+  TinyWireM.endTransmission();
+#else
   Wire.beginTransmission(MCP23008_ADDRESS | i2caddr);
 #if ARDUINO >= 100
   Wire.write((byte)addr);
@@ -174,4 +208,5 @@ void Adafruit_MCP23008::write8(uint8_t addr, uint8_t data) {
   Wire.send(data);
 #endif
   Wire.endTransmission();
+#endif
 }


### PR DESCRIPTION
(duplicated from the Adafruit_MCP23008 repo, since the same code lives in both places)

Unlike a lot of people, who try Arduino and then end up moving in a direction of more power and more capability (bigger and better), I'm going in the opposite direction.  :-)  I've been getting into ATtiny stuff...to see just how much I can squeeze out of these (um) tiny chips.

I did find one other library out there (LiquidCrystal_I2C) with TinyWireM support, but it's written for the PCF8574 IO expander, not the MCP23008.  So that didn't work with the Adafruit LCD backpack...and I was determined to stick with that hardware and get it working with the ATtiny85 with the least amount of work possible.  :-)

Turns out it was trivial.  All I did was tweak Adafruit_MCP23008.cpp, using TinyWireM library calls in place of Wire calls, and badabing badaboom.

I've tested this with both 1 MHz and 8 MHz internal oscillator frequencies with both of the common flavors of ATtiny85 cores:

http://hlt.media.mit.edu/?p=1695
...and:
http://code.google.com/p/arduino-tiny/

...and it works swimmingly.  Please consider integrating this change to the library.  Thanks!